### PR TITLE
그룹스터디 테스트

### DIFF
--- a/src/main/java/com/witherview/database/entity/StudyFeedback.java
+++ b/src/main/java/com/witherview/database/entity/StudyFeedback.java
@@ -16,12 +16,12 @@ public class StudyFeedback extends CreatedBaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "target_user_id", nullable = false)
-    private User receivedUser; // 받은 사람람 (조회할 때 사용할 필드)
+    @JoinColumn(name = "received_user_id", nullable = false)
+    private User receivedUser; // 받은 사람 (조회할 때 사용할 필드)
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "written_user_id", nullable = false)
-    private User sendUser; // 보낸 사
+    @JoinColumn(name = "send_user_id", nullable = false)
+    private User sendUser; // 보낸 사람
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_history_id", nullable = false)

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyController.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyController.java
@@ -31,6 +31,9 @@ public class GroupStudyController {
     private final GroupStudyService groupStudyService;
 
     @ApiOperation(value="특정 스터디방 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name="authorization", paramType = "header")
+    })
     @GetMapping("/room/{id}")
     public ResponseEntity<?> findSpecificRoom(
             @ApiParam(value = "조회할 방 id") @PathVariable("id") Long id) {
@@ -96,6 +99,9 @@ public class GroupStudyController {
 
 
     @ApiOperation(value="전체 / 카테고리별 스터디룸 데이터 조회.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name="authorization", paramType = "header")
+    })
     @GetMapping("/room")
     public ResponseEntity<?> findAllRooms(
             @ApiParam(value = "조회할 방 카테고리")
@@ -115,6 +121,9 @@ public class GroupStudyController {
     }
 
     @ApiOperation(value="해당 스터디방 참여자 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name="authorization", paramType = "header")
+    })
     @GetMapping(path = "/room/{id}/participants")
     public ResponseEntity<?> findParticipants(
             @ApiParam(value = "참여 조회할 방 id") @PathVariable Long id

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
@@ -1,7 +1,6 @@
 package com.witherview.groupPractice.GroupStudy;
 
-import com.witherview.database.entity.StudyRoom;
-import lombok.Builder;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
@@ -28,9 +27,10 @@ public class GroupStudyDTO {
         private String industry;
         private String job;
 
-        private String date;
-        private String time;
-
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate date;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalTime time;
     }
 
     @Getter @Setter
@@ -48,8 +48,10 @@ public class GroupStudyDTO {
         private String industry;
         private String job;
 
-        private String date;
-        private String time;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate date;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalTime time;
     }
 
     @Getter @Setter
@@ -61,7 +63,7 @@ public class GroupStudyDTO {
         private Long historyId;
 
         @NotNull(message = "타겟 유저아이디는 반드시 입력해야 합니다.")
-        private String receivedUser; // 이메일?
+        private String receivedUser;
 
         @NotNull(message = "점수는 반드시 입력해야 합니다.")
         private Byte score;
@@ -92,7 +94,7 @@ public class GroupStudyDTO {
 
     @Getter @Setter
     public static class ParticipantDTO {
-        private Long id;
+        private String id;
         private String email;
         private String name;
         private Long groupPracticeCnt;
@@ -103,7 +105,9 @@ public class GroupStudyDTO {
     @Getter @Setter
     public static class FeedBackResponseDTO {
         private Long id;
-        private Long targetUserId;
+        // TODO: receivedUserId 조회 안됨
+        //  modelMapper에서는 receivedUser 엔티티의 id 값으로 바로 매핑됐는데 mapStruct은 왜 안되는지 의문...
+//        private String receivedUserId;
         private Byte score;
         private Boolean passOrFail;
     }

--- a/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
+++ b/src/main/java/com/witherview/groupPractice/GroupStudy/GroupStudyDTO.java
@@ -105,9 +105,7 @@ public class GroupStudyDTO {
     @Getter @Setter
     public static class FeedBackResponseDTO {
         private Long id;
-        // TODO: receivedUserId 조회 안됨
-        //  modelMapper에서는 receivedUser 엔티티의 id 값으로 바로 매핑됐는데 mapStruct은 왜 안되는지 의문...
-//        private String receivedUserId;
+        private String receivedUserId;
         private Byte score;
         private Boolean passOrFail;
     }

--- a/src/main/java/com/witherview/groupPractice/history/StudyHistoryController.java
+++ b/src/main/java/com/witherview/groupPractice/history/StudyHistoryController.java
@@ -1,23 +1,25 @@
 package com.witherview.groupPractice.history;
 
-import com.witherview.account.AccountSession;
 import com.witherview.database.entity.StudyHistory;
 import com.witherview.exception.ErrorCode;
 import com.witherview.exception.ErrorResponse;
 import com.witherview.groupPractice.GroupStudy.GroupStudyDTO;
+import com.witherview.utils.AuthTokenParsing;
+import com.witherview.utils.StudyHistoryMapper;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
 
-import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
 @Api(tags = "StudyHistory API")
@@ -25,32 +27,39 @@ import javax.validation.Valid;
 @RestController
 @RequestMapping("/api/group/history")
 public class StudyHistoryController {
-    private final ModelMapper modelMapper;
     private final StudyHistoryService studyHistoryService;
+    private final StudyHistoryMapper studyHistoryMapper;
 
     @ApiOperation(value = "스터디 연습 내역 등록")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name="Authorization", paramType = "header")
+    })
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> saveStudyHistory(@RequestBody @Valid GroupStudyDTO.StudyRequestDTO requestDto,
-                                              BindingResult result,
-                                              @ApiIgnore HttpSession session) {
-        if(result.hasErrors()) {
-            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, result);
+                                              BindingResult error,
+                                              @ApiIgnore Authentication authentication) {
+        if(error.hasErrors()) {
+            ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, error);
             return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
         }
-        AccountSession accountSession = (AccountSession) session.getAttribute("user");
-        StudyHistory studyHistory = studyHistoryService.saveStudyHistory(requestDto.getId(), accountSession.getId().toString());
-        return new ResponseEntity<>(modelMapper.map(studyHistory,
-                StudyHistoryDTO.HistoryCreatedResponseDTO.class), HttpStatus.CREATED);
+        String userId = AuthTokenParsing.getAuthClaimValue(authentication, "userId");
+        StudyHistory studyHistory = studyHistoryService.saveStudyHistory(requestDto.getId(), userId);
+        return new ResponseEntity<>(studyHistoryMapper.toHistoryCreatedDto(studyHistory), HttpStatus.CREATED);
     }
 
     @ApiOperation(value = "스터디 녹화 등록")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name="Authorization", paramType = "header")
+    })
     @PostMapping(path = "/video", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> uploadVideo(@RequestParam("videoFile") MultipartFile videoFile,
                                          @RequestParam("studyHistoryId") Long studyHistoryId,
-                                         @ApiIgnore HttpSession session) {
-        AccountSession accountSession = (AccountSession) session.getAttribute("user");
-        StudyHistory studyHistory = studyHistoryService.uploadVideo(videoFile, studyHistoryId, accountSession.getId().toString());
-        return new ResponseEntity<>(modelMapper.map(studyHistory, StudyHistoryDTO.HistoryResponseDTO.class), HttpStatus.OK);
+                                         @ApiIgnore Authentication authentication) {
+        String userId = AuthTokenParsing.getAuthClaimValue(authentication, "userId");
+        StudyHistory studyHistory = studyHistoryService.uploadVideo(videoFile, studyHistoryId, userId);
+        return new ResponseEntity<>(studyHistoryMapper.toVideoSavedDto(studyHistory), HttpStatus.OK);
     }
+
+    // TODO: 스터디 조회 api 작성 필요
 }

--- a/src/main/java/com/witherview/utils/GroupStudyMapper.java
+++ b/src/main/java/com/witherview/utils/GroupStudyMapper.java
@@ -5,6 +5,7 @@ import com.witherview.database.entity.StudyRoom;
 import com.witherview.database.entity.User;
 import com.witherview.groupPractice.GroupStudy.GroupStudyDTO;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
 import java.util.List;
@@ -18,7 +19,8 @@ public interface GroupStudyMapper {
     GroupStudyDTO.ResponseDTO toResponseDto(StudyRoom studyRoom);
     GroupStudyDTO.ResponseDTO[] toResponseDtoArray(List<StudyRoom> studyRoomList);
     GroupStudyDTO.DeleteResponseDTO toDeleteResponseDto(StudyRoom studyRoom);
-    GroupStudyDTO.ParticipantDTO toParticipantDto(StudyRoom studyRoom);
+//    GroupStudyDTO.ParticipantDTO toParticipantDto(StudyRoom studyRoom);
+    @Mapping(source = "receivedUser.id", target = "receivedUserId")
     GroupStudyDTO.FeedBackResponseDTO toFeedBackResponseDto(StudyFeedback studyFeedback);
 
 }

--- a/src/main/java/com/witherview/utils/StudyHistoryMapper.java
+++ b/src/main/java/com/witherview/utils/StudyHistoryMapper.java
@@ -1,0 +1,13 @@
+package com.witherview.utils;
+
+import com.witherview.database.entity.StudyHistory;
+import com.witherview.groupPractice.history.StudyHistoryDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedSourcePolicy = ReportingPolicy.IGNORE)
+public interface StudyHistoryMapper {
+    StudyHistoryDTO.HistoryCreatedResponseDTO toHistoryCreatedDto(StudyHistory studyHistory);
+    StudyHistoryDTO.HistoryResponseDTO toHistoryResponseDto(StudyHistory studyHistory);
+    StudyHistoryDTO.VideoSaveResponseDTO toVideoSavedDto(StudyHistory studyHistory);
+}


### PR DESCRIPTION
### TO DO
- [ ] 테스트 코드 작성 (postman으로 동작은 다 확인했는데 테스트 코드 작성을 제대로 못해가지고 오늘 내로 완성하고 올리겠습니당~!)
### Done
- [x] 스터디룸 생성
- [x] 스터디룸 수정
- [x] 스터디룸 삭제
- [x] 특정 스터디룸 조회
- [x] 스터디룸 조회 (카테고리, 페이지 별)
- [x] 해당 스터디룸 참여자 조회
- [x] 스터디룸 참여
- [x] 스터디룸 나가기
- [x] 스터디 피드백 
- [x] 스터디 연습 내역 등록 

### 의문점 
```java
@Getter @Setter
    public static class FeedBackResponseDTO {
        private Long id;
        private String receivedUserId;
        private Byte score;
        private Boolean passOrFail;
    }
```

- receivedUserId 경우 modelMapper에서는 receivedUser 객체의 id 값으로 바로 매핑되었는데 mapStruct에서는 안됨...GroupStudyMapperImpl 에 반영이 안되어서 그럴 가능성도 있긴하지만 (그러기엔 여러번 시도 해봤으나 안됨)..

### 변경 사항
**GroupStudyDTO**
- StudyCreateDTO, StudyUpdateDTO date, time 타입 변경  & JsonFormat 으로 형식 체크 
→ String처럼 입력하면서 date, time 형식 검증 가능함 
  - 기존 String 일 때는 date, time 형식에 맞지 않게 입력들어올 경우 데이터 삽입 시 오류 발생 ( 올바른 경로로 들어올 경우 형식에 안맞지는 않겠지만 혹시 모를 상황에 대비)
  - GroupStudyService의 updateRoom에서  
  
    ```java
       var localDate = StringUtils.toLocalDate(requestDto.getDate());
       var localTime = StringUtils.toLocalTime(requestDto.getTime());
    ```
    만약 dto에 date, time 데이터 안들어왔을 경우 위 코드에서 NullPointerException 발생 
 - ParticipantDTO 에서 유저 아이디 타입이 Long으로 되어있길래 String 으로 수정 

**GroupStudyService**
- @Transactional 어노테이션 붙임 → 안붙이니 db 반영안됨 !!
- `studyRoomParticipantRepository.findByStudyRoomIdAndUserId(id, userId)
                .orElseThrow(NotJoinedStudyRoom::new);`   
  저렇게 처리하면 방 참가가 안됨! Participant 이 없어야 참가 가능한데 없으면 오류처리해버리니... 그래서 참여 하지 않고 있는경우 **null 반환** 하도록 바꿨습니다.

**GroupStudyController**
- delete api 에서 응답메세지 아무것도 안주니 뭔가 이상해서 삭제한 방 id 응답하도록 일단 바꿨습니다.
- 스터디방 참여 api 에서 불필요한 부분(BindingResult, produce, consume = MediaType.APPLICATION_JSON_VALUE) 삭제 

**StudyHistoryController**
- 여기는 토큰 적용이 안되어 있길래 토큰 사용하도록 바꿨습니다...(아마 작업이 덜 된거 같긴한데 피드백 등록할 때 여기 api 를 사용해야해서 일단 제가 바꿨습니더..ㅎㅎ)

### 안되는 부분
- swagger header에 토큰 넣었는데 적용이 안됩니다. 이부분은 추후에 더 볼 예정 
