### PR TITLE
Feature/upload/image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ repositories {
 }
 
 dependencies {
-	compile 'org.modelmapper:modelmapper:2.3.0'
 	// mapStruct
 	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
@@ -55,10 +54,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	// restTemplate Exception 처리를 위한 dependency
 	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+	// AWS s3 연결
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-	runtime 'io.jsonwebtoken:jjwt-impl:0.11.2'
-	runtime 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/witherview/configuration/AwsStorageConfig.java
+++ b/src/main/java/com/witherview/configuration/AwsStorageConfig.java
@@ -1,0 +1,28 @@
+package com.witherview.configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsStorageConfig {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region).build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,19 @@ logging:
   level:
     org.hibernate: error
 
+cloud:
+  aws:
+    credentials:
+      access-key: AKIAZ3SKFZJOKETNMGPV
+      secret-key: 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
+    stack:
+      auto: false
+    region:
+      static: ap-northeast-2
+
+application:
+  bucket:
+    name: yapp-storage
 
 ---
 


### PR DESCRIPTION
AWS S3에 이미지파일 업로드 / 조회 / 삭제 로직입니다.

추후에 생각해야 할 점
- 트래픽이 많아질 경우 조회를 S3에서 직접 하는 대신, 캐시된 이미지를 가져오는 게 S3 부하를 낮출 수 있음.
- 방법으로는 AWS CDN을 사용하거나, Java Spring의 캐시 사용하기 (jcache 등)